### PR TITLE
Int32Array if supp + Caching vendor specific props + Optimum alpha hex shifting + Minor opts

### DIFF
--- a/hqx.js
+++ b/hqx.js
@@ -213,8 +213,24 @@ window.hqx = function( img, scale ) {
 	
 	// pack RGBA colors into integers
 	var count = img.width * img.height;
-	var src = _src = new Array(count);
-	var dest = _dest = new Array(count*scale*scale);
+
+	if (window.ArrayBuffer) {
+		if (!window.hqxBufferSrc || window.hqxBufferSrc.byteLength < count * 4) {
+			window.hqxBufferSrc = new ArrayBuffer(count * 4);
+		}
+
+		if (!window.hqxBufferDest || window.hqxBufferDest.byteLength < count * scale * scale * 4) {
+			window.hqxBufferDest = new ArrayBuffer(count * scale * scale * 4);
+		}
+
+		var src = _src = new Int32Array(window.hqxBufferSrc);
+		var dest = _dest = new Int32Array(window.hqxBufferDest);
+	}
+	else {
+		var src = _src = new Array(count);
+		var dest = _dest = new Array(count*scale*scale);
+	}
+
 	var index;
 	for(var i = 0; i < count; i++) {
 		src[i] = (origPixels[(index = i << 2)+3] << 24) +

--- a/hqx.js
+++ b/hqx.js
@@ -275,10 +275,9 @@ window.hqx = function( img, scale ) {
 	var scaledPixelsData = scaledPixels.data;
 	
 	// unpack integers to RGBA
-	var c, alpha;
+	var c;
 	for( var j = 0; j < destPxCount; j++ ) {
-		alpha = ((c = dest[j]) & 0xFF000000) >> 24;
-		scaledPixelsData[(index = j << 2)+3] = alpha < 0 ? alpha + 256 : 0; // signed/unsigned :/
+		scaledPixelsData[(index = j << 2)+3] = ((c = dest[j]) & 0xFF000000) >>> 24;
 		scaledPixelsData[index+2] = (c & 0x00FF0000) >> 16;
 		scaledPixelsData[index+1] = (c & 0x0000FF00) >> 8;
 		scaledPixelsData[index] = c & 0x000000FF;


### PR DESCRIPTION
- using `Int32Array()` if supported (fallback to common `Array`);
- caching `ratio` and `getImageDataHD` after first use;
- optimized `getImagePixels`;
- optimum signed/unsigned `alpha` shift from destination array;
- minor optimizations.
